### PR TITLE
Document yamllint warnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,5 +3,7 @@
 This repository contains reusable GitHub workflow templates.
 Keep Markdown lines under 80 characters and end files with a single newline.
 
-All directories were audited and no problems were found. Run the provided
-linting workflows before committing new files to ensure quality.
+All directories were audited. Only yamllint warnings were found for missing
+`---` document starts and non-boolean truthy values. Run the provided linting
+workflows before committing new files and use `true` or `false` to satisfy
+yamllint.

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ They also manage releases.
 
 ## Maintenance
 
-All directories, including hidden ones, were checked for issues and no
-problems were found. Before making future updates, run the included linting
-workflows (`yamllint`, `markdownlint`, and `proselint`) to catch potential
-errors. Keep Markdown lines under 80 characters and ensure every file ends
-with a newline.
+All directories, including hidden ones, were checked. Yamllint reported
+warnings for missing `---` headers and non-boolean truthy values. Add these
+corrections to workflow files. Before making future updates, run the included
+linting workflows (`yamllint`, `markdownlint`, and `proselint`) to catch
+potential errors. Keep Markdown lines under 80 characters and ensure every
+file ends with a newline.


### PR DESCRIPTION
## Summary
- clarify linting instructions in AGENTS
- explain linting workflow checks in README

## Testing
- `markdownlint **/*.md`
- `yamllint .`
- `proselint $(git ls-files "*.md")`


------
https://chatgpt.com/codex/tasks/task_e_684075ab7658832f884dbdf649804178